### PR TITLE
Updated the grep data for the cipher test case

### DIFF
--- a/thm-troubleshoot
+++ b/thm-troubleshoot
@@ -48,7 +48,7 @@ fin(){
 connect(){
 	testSuccess() ( if grep -qio "Initialization Sequence Completed" $ovpnoutput;then return 0; else return 1;fi )
 	testCert() ( if grep -qioE "Cannot load inline certificate file|certificate verify failed|cannot load CA" $ovpnoutput;then return 0; else return 1;fi )
-	testCipher() ( if grep -qio "OpenVPN ignores --cipher for cipher negotiations|OPTIONS ERROR: failed to negotiate cipher with server" $ovpnoutput;then return 0; else return 1;fi )
+	testCipher() ( if grep -qioE "OpenVPN ignores --cipher for cipher negotiations|OPTIONS ERROR: failed to negotiate cipher with server" $ovpnoutput;then return 0; else return 1;fi )
 	ovpnoutput=$(mktemp)
 	openvpn $ovpn </dev/null &>$ovpnoutput &
 	colour process "[+] Connecting...." 10

--- a/thm-troubleshoot
+++ b/thm-troubleshoot
@@ -48,7 +48,7 @@ fin(){
 connect(){
 	testSuccess() ( if grep -qio "Initialization Sequence Completed" $ovpnoutput;then return 0; else return 1;fi )
 	testCert() ( if grep -qioE "Cannot load inline certificate file|certificate verify failed|cannot load CA" $ovpnoutput;then return 0; else return 1;fi )
-	testCipher() ( if grep -qio "OpenVPN ignores --cipher for cipher negotiations." $ovpnoutput;then return 0; else return 1;fi )
+	testCipher() ( if grep -qio "OpenVPN ignores --cipher for cipher negotiations|OPTIONS ERROR: failed to negotiate cipher with server" $ovpnoutput;then return 0; else return 1;fi )
 	ovpnoutput=$(mktemp)
 	openvpn $ovpn </dev/null &>$ovpnoutput &
 	colour process "[+] Connecting...." 10
@@ -67,6 +67,7 @@ connect(){
 			sed -i 's/cipher AES-256-CBC/data-ciphers AES-256-CBC/' $ovpn
 			colour green "[+] Successfully updated cipher switch! Please connect to the vpn using the following command: "
 			colour code "sudo openvpn $ovpn" 2
+			
 			return 0
 		fi
 		if [ $i -le 1 ]; then


### PR DESCRIPTION
Updated the test case for the cipher check to check for "OPTIONS ERROR: failed to negotiate cipher with server" as well as the other error statement for specific OpenVPN versions.

And added "E" to the grep switches.